### PR TITLE
refactor: cleanup & restructuring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,4 +11,60 @@ name = "osu-native"
 version = "0.1.0"
 dependencies = [
  "libosu-native-sys",
+ "thiserror",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/libosu-native-sys/build.rs
+++ b/libosu-native-sys/build.rs
@@ -2,7 +2,7 @@ use std::{env, error::Error};
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
     let outdir = env::var("CARGO_MANIFEST_DIR").or(Err("No output directory"))?;
-    println!("cargo:rustc-link-search={}", outdir);
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", outdir);
+    println!("cargo:rustc-link-search={outdir}");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{outdir}");
     Ok(())
 }

--- a/libosu-native-sys/src/lib.rs
+++ b/libosu-native-sys/src/lib.rs
@@ -56,7 +56,7 @@ pub struct NativeScoreHitStatistics {
 }
 
 #[repr(i8)]
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum ErrorCode {
     BufferSizeQuery = -1,
     Success = 0,

--- a/osu-native/Cargo.toml
+++ b/osu-native/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 libosu-native-sys = { path = "../libosu-native-sys" }
+thiserror = "2.0.14"

--- a/osu-native/src/beatmap/mod.rs
+++ b/osu-native/src/beatmap/mod.rs
@@ -22,7 +22,7 @@ pub struct Beatmap {
 }
 
 impl Beatmap {
-    pub fn get_handle(&self) -> i32 {
+    pub fn handle(&self) -> i32 {
         self.handle
     }
 }
@@ -79,15 +79,15 @@ impl Beatmap {
         beatmap.map_err(Into::into)
     }
 
-    pub fn get_title(&self) -> Result<String, BeatmapError> {
+    pub fn title(&self) -> Result<String, BeatmapError> {
         read_native_string(self.handle, Beatmap_GetTitle).map_err(Into::into)
     }
 
-    pub fn get_artist(&self) -> Result<String, BeatmapError> {
+    pub fn artist(&self) -> Result<String, BeatmapError> {
         read_native_string(self.handle, Beatmap_GetArtist).map_err(Into::into)
     }
 
-    pub fn get_version(&self) -> Result<String, BeatmapError> {
+    pub fn version(&self) -> Result<String, BeatmapError> {
         read_native_string(self.handle, Beatmap_GetVersion).map_err(Into::into)
     }
 }
@@ -112,11 +112,11 @@ mod tests {
     #[test]
     fn test_get_strings() {
         let map = Beatmap::new_from_path(initialize_path()).unwrap();
-        let title = map.get_title().unwrap();
+        let title = map.title().unwrap();
         assert_eq!(title, String::from("Toy Box"));
-        let artist = map.get_artist().unwrap();
+        let artist = map.artist().unwrap();
         assert_eq!(artist, String::from("John Grant"));
-        let version = map.get_version().unwrap();
+        let version = map.version().unwrap();
         assert_eq!(version, String::from("Expert"));
     }
 }

--- a/osu-native/src/calculator/catch.rs
+++ b/osu-native/src/calculator/catch.rs
@@ -31,8 +31,8 @@ impl DifficultyCalculator for CatchDifficultyCalculator {
 
         unsafe {
             match CatchDifficultyCalculator_Create(
-                ruleset.get_handle(),
-                beatmap.get_handle(),
+                ruleset.handle(),
+                beatmap.handle(),
                 &raw mut handle,
             ) {
                 ErrorCode::Success => Ok(Self { handle }),

--- a/osu-native/src/calculator/catch.rs
+++ b/osu-native/src/calculator/catch.rs
@@ -5,7 +5,7 @@ use libosu_native_sys::{
     CatchDifficultyCalculator_Destroy, ErrorCode, NativeCatchDifficultyAttributes,
 };
 
-use crate::error::{OsuError, error_code_to_osu};
+use crate::error::OsuError;
 
 use super::DifficultyCalculator;
 
@@ -28,6 +28,7 @@ impl DifficultyCalculator for CatchDifficultyCalculator {
         beatmap: crate::beatmap::Beatmap,
     ) -> Result<Self, OsuError> {
         let mut handle = 0;
+
         unsafe {
             match CatchDifficultyCalculator_Create(
                 ruleset.get_handle(),
@@ -35,19 +36,21 @@ impl DifficultyCalculator for CatchDifficultyCalculator {
                 &raw mut handle,
             ) {
                 ErrorCode::Success => Ok(Self { handle }),
-                e => Err(error_code_to_osu(e)),
+                e => Err(e.into()),
             }
         }
     }
 
     fn calculate(&self) -> Result<Self::Attributes, OsuError> {
         let mut attributes: MaybeUninit<Self::NativeAttributes> = MaybeUninit::uninit();
+
         let attributes = unsafe {
             match CatchDifficultyCalculator_Calculate(self.handle, attributes.as_mut_ptr()) {
                 ErrorCode::Success => Ok(attributes.assume_init().into()),
-                e => Err(error_code_to_osu(e)),
+                e => Err(e.into()),
             }
         };
+
         attributes
     }
 }

--- a/osu-native/src/calculator/mania.rs
+++ b/osu-native/src/calculator/mania.rs
@@ -31,8 +31,8 @@ impl DifficultyCalculator for ManiaDifficultyCalculator {
 
         unsafe {
             match ManiaDifficultyCalculator_Create(
-                ruleset.get_handle(),
-                beatmap.get_handle(),
+                ruleset.handle(),
+                beatmap.handle(),
                 &raw mut handle,
             ) {
                 ErrorCode::Success => Ok(Self { handle }),

--- a/osu-native/src/calculator/mod.rs
+++ b/osu-native/src/calculator/mod.rs
@@ -1,13 +1,12 @@
-use crate::{beatmap::Beatmap, error::OsuError, ruleset::Ruleset};
+use crate::{beatmap::Beatmap, error::OsuError, ruleset::Ruleset, utils::HasNative};
 
 pub mod catch;
 pub mod mania;
 pub mod osu;
 pub mod taiko;
 
-trait DifficultyCalculator: Sized {
-    type Attributes;
-    type NativeAttributes;
+pub trait DifficultyCalculator: Sized {
+    type Attributes: HasNative;
 
     fn new(ruleset: Ruleset, beatmap: Beatmap) -> Result<Self, OsuError>;
 

--- a/osu-native/src/calculator/mod.rs
+++ b/osu-native/src/calculator/mod.rs
@@ -1,18 +1,15 @@
-use crate::{
-    beatmap::Beatmap,
-    error::{NativeError, OsuError},
-    ruleset::Ruleset,
-};
+use crate::{beatmap::Beatmap, error::OsuError, ruleset::Ruleset};
+
 pub mod catch;
 pub mod mania;
 pub mod osu;
 pub mod taiko;
 
-trait DifficultyCalculator {
+trait DifficultyCalculator: Sized {
     type Attributes;
     type NativeAttributes;
-    fn new(ruleset: Ruleset, beatmap: Beatmap) -> Result<Self, OsuError>
-    where
-        Self: Sized;
+
+    fn new(ruleset: Ruleset, beatmap: Beatmap) -> Result<Self, OsuError>;
+
     fn calculate(&self) -> Result<Self::Attributes, OsuError>;
 }

--- a/osu-native/src/calculator/osu.rs
+++ b/osu-native/src/calculator/osu.rs
@@ -27,8 +27,8 @@ impl DifficultyCalculator for OsuDifficultyCalculator {
         let mut handle = 0;
         unsafe {
             match OsuDifficultyCalculator_Create(
-                ruleset.get_handle(),
-                beatmap.get_handle(),
+                ruleset.handle(),
+                beatmap.handle(),
                 &raw mut handle,
             ) {
                 ErrorCode::Success => Ok(Self { handle }),

--- a/osu-native/src/calculator/osu.rs
+++ b/osu-native/src/calculator/osu.rs
@@ -111,7 +111,7 @@ mod tests {
     };
 
     #[test]
-    fn test_toy_box_standard() -> () {
+    fn test_toy_box_standard() {
         let beatmap = Beatmap::from_path(initialize_path()).unwrap();
         let ruleset = Ruleset::new(RulesetKind::Osu).unwrap();
         let calculator = OsuDifficultyCalculator::new(ruleset, beatmap).unwrap();

--- a/osu-native/src/calculator/taiko.rs
+++ b/osu-native/src/calculator/taiko.rs
@@ -31,8 +31,8 @@ impl DifficultyCalculator for TaikoDifficultyCalculator {
 
         unsafe {
             match TaikoDifficultyCalculator_Create(
-                ruleset.get_handle(),
-                beatmap.get_handle(),
+                ruleset.handle(),
+                beatmap.handle(),
                 &raw mut handle,
             ) {
                 ErrorCode::Success => Ok(Self { handle }),

--- a/osu-native/src/calculator/taiko.rs
+++ b/osu-native/src/calculator/taiko.rs
@@ -5,11 +5,17 @@ use libosu_native_sys::{
     TaikoDifficultyCalculator_Create, TaikoDifficultyCalculator_Destroy,
 };
 
-use crate::error::OsuError;
+use crate::{
+    beatmap::Beatmap,
+    error::OsuError,
+    ruleset::Ruleset,
+    utils::{HasNative, NativeType},
+};
 
 use super::DifficultyCalculator;
 
-struct TaikoDifficultyCalculator {
+#[derive(PartialEq, Eq)]
+pub struct TaikoDifficultyCalculator {
     handle: i32,
 }
 
@@ -21,37 +27,34 @@ impl Drop for TaikoDifficultyCalculator {
 
 impl DifficultyCalculator for TaikoDifficultyCalculator {
     type Attributes = TaikoDifficultyAttributes;
-    type NativeAttributes = NativeTaikoDifficultyAttributes;
 
-    fn new(
-        ruleset: crate::ruleset::Ruleset,
-        beatmap: crate::beatmap::Beatmap,
-    ) -> Result<Self, OsuError> {
+    fn new(ruleset: Ruleset, beatmap: Beatmap) -> Result<Self, OsuError> {
         let mut handle = 0;
 
-        unsafe {
-            match TaikoDifficultyCalculator_Create(
-                ruleset.handle(),
-                beatmap.handle(),
-                &raw mut handle,
-            ) {
-                ErrorCode::Success => Ok(Self { handle }),
-                e => Err(e.into()),
-            }
+        let code = unsafe {
+            TaikoDifficultyCalculator_Create(ruleset.handle(), beatmap.handle(), &mut handle)
+        };
+
+        if code != ErrorCode::Success {
+            return Err(code.into());
         }
+
+        Ok(Self { handle })
     }
 
     fn calculate(&self) -> Result<Self::Attributes, OsuError> {
-        let mut attributes: MaybeUninit<Self::NativeAttributes> = MaybeUninit::uninit();
+        let mut attributes: MaybeUninit<NativeType<Self::Attributes>> = MaybeUninit::uninit();
 
-        let attributes = unsafe {
-            match TaikoDifficultyCalculator_Calculate(self.handle, attributes.as_mut_ptr()) {
-                ErrorCode::Success => Ok(attributes.assume_init().into()),
-                e => Err(e.into()),
-            }
-        };
+        let code =
+            unsafe { TaikoDifficultyCalculator_Calculate(self.handle, attributes.as_mut_ptr()) };
 
-        attributes
+        if code != ErrorCode::Success {
+            return Err(code.into());
+        }
+
+        let native = unsafe { attributes.assume_init() };
+
+        Ok(native.into())
     }
 }
 
@@ -66,6 +69,10 @@ pub struct TaikoDifficultyAttributes {
     pub rhythm_top_strains: f64,
     pub colour_top_strains: f64,
     pub stamina_top_strains: f64,
+}
+
+impl HasNative for TaikoDifficultyAttributes {
+    type Native = NativeTaikoDifficultyAttributes;
 }
 
 impl From<NativeTaikoDifficultyAttributes> for TaikoDifficultyAttributes {
@@ -90,14 +97,14 @@ mod tests {
     use crate::{
         beatmap::Beatmap,
         calculator::{DifficultyCalculator, taiko::TaikoDifficultyCalculator},
-        ruleset::{Ruleset, Rulesets},
+        ruleset::{Ruleset, RulesetKind},
         utils::initialize_path,
     };
 
     #[test]
     fn test_toy_box_convert_taiko() {
-        let beatmap = Beatmap::new_from_path(initialize_path()).unwrap();
-        let ruleset = Ruleset::new_from_variant(Rulesets::Taiko).unwrap();
+        let beatmap = Beatmap::from_path(initialize_path()).unwrap();
+        let ruleset = Ruleset::new(RulesetKind::Taiko).unwrap();
         let calculator = TaikoDifficultyCalculator::new(ruleset, beatmap).unwrap();
         let attributes = calculator.calculate().unwrap();
         assert_eq!(attributes.star_rating, 3.4385310622836567);

--- a/osu-native/src/error.rs
+++ b/osu-native/src/error.rs
@@ -1,60 +1,41 @@
-use std::fmt::Display;
-
 use libosu_native_sys::ErrorCode;
-#[derive(Debug)]
+use thiserror::Error as ThisError;
+
+#[derive(Debug, ThisError)]
 pub enum NativeError {
+    #[error("Native object not found")]
     ObjectNotFound,
+    #[error("Specified ruleset is unavailable")]
     RulesetUnavailable,
-    BeatmapFileNotFound(String),
+    #[error("Beatmap file with specified path was not found")]
+    BeatmapFileNotFound,
+    #[error("Unknown error")]
     UnknownError,
 }
-impl Display for NativeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NativeError::ObjectNotFound => writeln!(f, "Native object not found"),
-            NativeError::RulesetUnavailable => writeln!(f, "Specified ruleset is unavailable"),
-            NativeError::BeatmapFileNotFound(v) => {
-                writeln!(f, "Beatmap file with specified path ({v}) is not found")
-            }
-            NativeError::UnknownError => writeln!(f, "Unknown error"),
-        }
-    }
-}
-impl std::error::Error for NativeError {}
+
 impl From<ErrorCode> for NativeError {
     fn from(value: ErrorCode) -> Self {
         match value {
             ErrorCode::ObjectNotFound => Self::ObjectNotFound,
             ErrorCode::RulesetUnavailable => Self::RulesetUnavailable,
-            ErrorCode::BeatmapFileNotFound => Self::BeatmapFileNotFound(String::new()),
+            ErrorCode::BeatmapFileNotFound => Self::BeatmapFileNotFound,
             _ => Self::UnknownError,
         }
     }
 }
-pub fn error_code_to_osu(error_code: ErrorCode) -> OsuError {
-    match error_code {
-        ErrorCode::ObjectNotFound => OsuError::NativeError(NativeError::ObjectNotFound),
-        ErrorCode::RulesetUnavailable => OsuError::NativeError(NativeError::RulesetUnavailable),
-        ErrorCode::BeatmapFileNotFound => {
-            OsuError::NativeError(NativeError::BeatmapFileNotFound(String::new()))
-        }
-        _ => OsuError::NativeError(NativeError::UnknownError),
-    }
-}
 
-#[derive(Debug)]
+#[derive(Debug, ThisError)]
 pub enum OsuError {
+    #[error("Library error, contact the developer")]
     LogicError,
-    NativeError(NativeError),
+    #[error("Native error")]
+    NativeError(#[from] NativeError),
+    #[error("Unknown error")]
     UnknownError,
 }
-impl Display for OsuError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OsuError::LogicError => writeln!(f, "Library error, contact the developer"),
-            OsuError::NativeError(e) => writeln!(f, "Native error: {e}"),
-            OsuError::UnknownError => writeln!(f, "Unknown error"),
-        }
+
+impl From<ErrorCode> for OsuError {
+    fn from(code: ErrorCode) -> Self {
+        Self::NativeError(code.into())
     }
 }
-impl std::error::Error for OsuError {}

--- a/osu-native/src/error.rs
+++ b/osu-native/src/error.rs
@@ -9,21 +9,22 @@ pub enum NativeError {
     RulesetUnavailable,
     #[error("Beatmap file with specified path was not found")]
     BeatmapFileNotFound,
-    #[error("Unknown error")]
-    UnknownError,
+    #[error("Unknown error code: {0:?}")]
+    UnknownError(ErrorCode),
 }
 
 impl From<ErrorCode> for NativeError {
-    fn from(value: ErrorCode) -> Self {
-        match value {
+    fn from(code: ErrorCode) -> Self {
+        match code {
             ErrorCode::ObjectNotFound => Self::ObjectNotFound,
             ErrorCode::RulesetUnavailable => Self::RulesetUnavailable,
             ErrorCode::BeatmapFileNotFound => Self::BeatmapFileNotFound,
-            _ => Self::UnknownError,
+            _ => Self::UnknownError(code),
         }
     }
 }
 
+// TODO: split this type up into whatever is needed
 #[derive(Debug, ThisError)]
 pub enum OsuError {
     #[error("Library error, contact the developer")]

--- a/osu-native/src/ruleset/mod.rs
+++ b/osu-native/src/ruleset/mod.rs
@@ -4,61 +4,66 @@ use libosu_native_sys::{ErrorCode, NativeRuleset, Ruleset_CreateFromId, Ruleset_
 use thiserror::Error as ThisError;
 
 use crate::{
-    error::{NativeError, OsuError},
-    utils::read_native_string,
+    error::NativeError,
+    utils::{HasNative, NativeType, StringError, read_native_string},
 };
 
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq)]
-pub enum Rulesets {
-    Standard = 0,
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum RulesetKind {
+    #[default]
+    Osu = 0,
     Taiko = 1,
     Catch = 2,
     Mania = 3,
 }
 
-impl From<Rulesets> for i32 {
-    fn from(value: Rulesets) -> Self {
-        match value {
-            Rulesets::Standard => 0,
-            Rulesets::Taiko => 1,
-            Rulesets::Catch => 2,
-            Rulesets::Mania => 3,
+impl From<RulesetKind> for i32 {
+    fn from(kind: RulesetKind) -> Self {
+        match kind {
+            RulesetKind::Osu => 0,
+            RulesetKind::Taiko => 1,
+            RulesetKind::Catch => 2,
+            RulesetKind::Mania => 3,
         }
     }
 }
 
-impl TryFrom<i32> for Rulesets {
-    type Error = RulesetError;
+#[derive(Debug, ThisError)]
+#[error("Invalid ruleset ID {0}")]
+pub struct InvalidRulesetId(i32);
 
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Rulesets::Standard),
-            1 => Ok(Rulesets::Taiko),
-            2 => Ok(Rulesets::Catch),
-            3 => Ok(Rulesets::Mania),
-            _ => Err(RulesetError::InvalidRuleset(value)),
+impl TryFrom<i32> for RulesetKind {
+    type Error = InvalidRulesetId;
+
+    fn try_from(id: i32) -> Result<Self, Self::Error> {
+        match id {
+            0 => Ok(RulesetKind::Osu),
+            1 => Ok(RulesetKind::Taiko),
+            2 => Ok(RulesetKind::Catch),
+            3 => Ok(RulesetKind::Mania),
+            _ => Err(InvalidRulesetId(id)),
         }
     }
 }
 
 #[derive(Debug, ThisError)]
 pub enum RulesetError {
-    #[error("Invalid ruleset ID {0}")]
-    InvalidRuleset(i32),
+    #[error(transparent)]
+    InvalidRuleset(#[from] InvalidRulesetId),
     #[error("Native error")]
-    GenericError(#[from] OsuError),
+    Native(#[from] NativeError),
 }
 
-impl From<NativeError> for RulesetError {
-    fn from(value: NativeError) -> Self {
-        Self::GenericError(value.into())
+impl From<ErrorCode> for RulesetError {
+    fn from(code: ErrorCode) -> Self {
+        Self::Native(code.into())
     }
 }
 
 pub struct Ruleset {
     handle: i32,
-    ruleset: Rulesets,
+    pub kind: RulesetKind,
 }
 
 impl Ruleset {
@@ -68,93 +73,81 @@ impl Ruleset {
 }
 
 impl Ruleset {
-    pub fn new_from_variant(variant: Rulesets) -> Result<Self, RulesetError> {
-        let mut ruleset: MaybeUninit<NativeRuleset> = MaybeUninit::uninit();
-        let ruleset = unsafe {
-            match Ruleset_CreateFromId(variant.into(), ruleset.as_mut_ptr()) {
-                ErrorCode::Success => Ok(ruleset.assume_init()),
-                e => Err(RulesetError::GenericError(e.into())),
-            }
-        };
+    pub fn new(kind: RulesetKind) -> Result<Self, RulesetError> {
+        let mut native: MaybeUninit<NativeType<Self>> = MaybeUninit::uninit();
 
-        ruleset.map(|r| Ruleset {
-            handle: r.handle,
-            ruleset: r.id.try_into().unwrap(),
+        let code = unsafe { Ruleset_CreateFromId(kind.into(), native.as_mut_ptr()) };
+
+        if code != ErrorCode::Success {
+            return Err(code.into());
+        }
+
+        let native = unsafe { native.assume_init() };
+
+        Ok(Self {
+            kind: native.id.try_into()?,
+            handle: native.handle,
         })
     }
 
-    pub fn short_name(&self) -> Result<String, RulesetError> {
-        read_native_string(self.handle, Ruleset_GetShortName).map_err(Into::into)
+    pub fn short_name(&self) -> Result<String, StringError> {
+        read_native_string(self.handle, Ruleset_GetShortName)
     }
+}
+
+impl HasNative for Ruleset {
+    type Native = NativeRuleset;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Ruleset, Rulesets};
+    use super::{Ruleset, RulesetKind};
 
     #[test]
-    fn test_create_standard() {
-        let osu = Ruleset::new_from_variant(Rulesets::Standard).unwrap();
-        assert_eq!(osu.ruleset, Rulesets::Standard);
+    fn test_create_osu() {
+        let osu = Ruleset::new(RulesetKind::Osu).unwrap();
+        assert_eq!(osu.kind, RulesetKind::Osu);
     }
 
     #[test]
     fn test_create_taiko() {
-        let taiko = Ruleset::new_from_variant(Rulesets::Taiko).unwrap();
-        assert_eq!(taiko.ruleset, Rulesets::Taiko);
+        let taiko = Ruleset::new(RulesetKind::Taiko).unwrap();
+        assert_eq!(taiko.kind, RulesetKind::Taiko);
     }
 
     #[test]
     fn test_create_catch() {
-        let catch = Ruleset::new_from_variant(Rulesets::Catch).unwrap();
-        assert_eq!(catch.ruleset, Rulesets::Catch);
+        let catch = Ruleset::new(RulesetKind::Catch).unwrap();
+        assert_eq!(catch.kind, RulesetKind::Catch);
     }
 
     #[test]
     fn test_create_mania() {
-        let mania = Ruleset::new_from_variant(Rulesets::Mania).unwrap();
-        assert_eq!(mania.ruleset, Rulesets::Mania);
+        let mania = Ruleset::new(RulesetKind::Mania).unwrap();
+        assert_eq!(mania.kind, RulesetKind::Mania);
     }
 
     #[test]
-    fn test_get_name_standard() {
-        let osu = Ruleset::new_from_variant(Rulesets::Standard).unwrap();
-        let _ = osu.short_name().unwrap();
+    fn test_get_name_osu() {
+        let osu = Ruleset::new(RulesetKind::Osu).unwrap();
+        assert_eq!(osu.short_name().unwrap(), "osu");
     }
 
     #[test]
     fn test_get_name_taiko() {
-        let taiko = Ruleset::new_from_variant(Rulesets::Taiko).unwrap();
-
-        assert_eq!(
-            taiko.short_name().unwrap(),
-            String::from("taiko"),
-            "Displayed {:?}",
-            taiko.short_name()
-        );
+        let taiko = Ruleset::new(RulesetKind::Taiko).unwrap();
+        assert_eq!(taiko.short_name().unwrap(), "taiko");
     }
 
     #[test]
     fn test_get_name_catch() {
-        let catch = Ruleset::new_from_variant(Rulesets::Catch).unwrap();
-
-        assert_eq!(
-            catch.short_name().unwrap(),
-            String::from("fruits"),
-            "Displayed {:?}",
-            catch.short_name()
-        );
+        let catch = Ruleset::new(RulesetKind::Catch).unwrap();
+        assert_eq!(catch.short_name().unwrap(), "fruits");
     }
 
     #[test]
     fn test_get_name_mania() {
-        let mania = Ruleset::new_from_variant(Rulesets::Mania).unwrap();
-
-        assert_eq!(
-            mania.short_name().unwrap(),
-            String::from("mania"),
-            "Displayed {:?}",
-            mania.short_name()
-        );
+        let mania = Ruleset::new(RulesetKind::Mania).unwrap();
+        assert_eq!(mania.short_name().unwrap(), "mania");
     }
 }

--- a/osu-native/src/ruleset/mod.rs
+++ b/osu-native/src/ruleset/mod.rs
@@ -62,7 +62,7 @@ pub struct Ruleset {
 }
 
 impl Ruleset {
-    pub fn get_handle(&self) -> i32 {
+    pub fn handle(&self) -> i32 {
         self.handle
     }
 }
@@ -83,7 +83,7 @@ impl Ruleset {
         })
     }
 
-    pub fn get_short_name(&self) -> Result<String, RulesetError> {
+    pub fn short_name(&self) -> Result<String, RulesetError> {
         read_native_string(self.handle, Ruleset_GetShortName).map_err(Into::into)
     }
 }
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn test_get_name_standard() {
         let osu = Ruleset::new_from_variant(Rulesets::Standard).unwrap();
-        let _ = osu.get_short_name().unwrap();
+        let _ = osu.short_name().unwrap();
     }
 
     #[test]
@@ -127,10 +127,10 @@ mod tests {
         let taiko = Ruleset::new_from_variant(Rulesets::Taiko).unwrap();
 
         assert_eq!(
-            taiko.get_short_name().unwrap(),
+            taiko.short_name().unwrap(),
             String::from("taiko"),
             "Displayed {:?}",
-            taiko.get_short_name()
+            taiko.short_name()
         );
     }
 
@@ -139,10 +139,10 @@ mod tests {
         let catch = Ruleset::new_from_variant(Rulesets::Catch).unwrap();
 
         assert_eq!(
-            catch.get_short_name().unwrap(),
+            catch.short_name().unwrap(),
             String::from("fruits"),
             "Displayed {:?}",
-            catch.get_short_name()
+            catch.short_name()
         );
     }
 
@@ -151,10 +151,10 @@ mod tests {
         let mania = Ruleset::new_from_variant(Rulesets::Mania).unwrap();
 
         assert_eq!(
-            mania.get_short_name().unwrap(),
+            mania.short_name().unwrap(),
             String::from("mania"),
             "Displayed {:?}",
-            mania.get_short_name()
+            mania.short_name()
         );
     }
 }

--- a/osu-native/src/utils/mod.rs
+++ b/osu-native/src/utils/mod.rs
@@ -49,7 +49,7 @@ pub(crate) fn read_native_string(
         .try_into()
         .map_err(|_| StringError::InvalidLength(size))?;
 
-    let mut buffer = vec![0u8, len];
+    let mut buffer = vec![0u8; len];
 
     let code = unsafe { func(handle, buffer.as_mut_ptr(), &mut size) };
 

--- a/osu-native/src/utils/mod.rs
+++ b/osu-native/src/utils/mod.rs
@@ -2,7 +2,7 @@ use std::{ffi::CString, path::PathBuf, ptr::null_mut};
 
 use libosu_native_sys::ErrorCode;
 
-use crate::error::{OsuError, error_code_to_osu};
+use crate::error::OsuError;
 
 pub(crate) fn read_native_string(
     handle: i32,
@@ -13,12 +13,14 @@ pub(crate) fn read_native_string(
     unsafe {
         match func(handle, null_mut(), &raw mut size) {
             ErrorCode::BufferSizeQuery => {}
-            e => return Err(error_code_to_osu(e).into()),
+            e => return Err(e.into()),
         }
     }
+
     println!("{size}");
 
     let mut buffer = Vec::with_capacity(size.try_into().unwrap());
+
     unsafe {
         match func(handle, buffer.as_mut_ptr(), &raw mut size) {
             ErrorCode::Success => {
@@ -26,9 +28,10 @@ pub(crate) fn read_native_string(
                 println!("{buffer:?}");
                 let string = CString::from_vec_with_nul(buffer).unwrap();
                 let string = string.into_string().unwrap();
+
                 return Ok(string);
             }
-            e => return Err(error_code_to_osu(e).into()),
+            e => return Err(e.into()),
         }
     }
 }
@@ -37,5 +40,6 @@ pub fn initialize_path() -> PathBuf {
     let manifest_path = std::env!("CARGO_MANIFEST_DIR");
     let mut path = PathBuf::from(manifest_path);
     path.push("standard.osu");
+
     path
 }

--- a/osu-native/src/utils/mod.rs
+++ b/osu-native/src/utils/mod.rs
@@ -1,44 +1,72 @@
-use std::{ffi::CString, path::PathBuf, ptr::null_mut};
+use std::{
+    ffi::{CString, FromVecWithNulError, IntoStringError},
+    ptr,
+};
 
 use libosu_native_sys::ErrorCode;
+use thiserror::Error as ThisError;
 
-use crate::error::OsuError;
+use crate::error::NativeError;
+
+/// Convenience alias for the native type of `T`.
+pub type NativeType<T> = <T as HasNative>::Native;
+
+pub trait HasNative {
+    type Native;
+}
+
+#[derive(Debug, ThisError)]
+pub enum StringError {
+    #[error("Received invalid length {0}")]
+    InvalidLength(i32),
+    #[error("Received invalid string")]
+    InvalidNul(#[from] FromVecWithNulError),
+    #[error("Received invalid utf8 string: {0:?}")]
+    InvalidUtf8(CString),
+    #[error("Native error")]
+    Native(#[from] NativeError),
+}
+
+impl From<ErrorCode> for StringError {
+    fn from(code: ErrorCode) -> Self {
+        Self::Native(code.into())
+    }
+}
 
 pub(crate) fn read_native_string(
     handle: i32,
     func: unsafe extern "C" fn(i32, *mut u8, *mut i32) -> ErrorCode,
-) -> Result<String, OsuError> {
+) -> Result<String, StringError> {
     let mut size = 0i32;
 
-    unsafe {
-        match func(handle, null_mut(), &raw mut size) {
-            ErrorCode::BufferSizeQuery => {}
-            e => return Err(e.into()),
-        }
+    let code = unsafe { func(handle, ptr::null_mut(), &mut size) };
+
+    if code != ErrorCode::BufferSizeQuery {
+        return Err(code.into());
     }
 
-    println!("{size}");
+    let len = size
+        .try_into()
+        .map_err(|_| StringError::InvalidLength(size))?;
 
-    let mut buffer = Vec::with_capacity(size.try_into().unwrap());
+    let mut buffer = vec![0u8, len];
 
-    unsafe {
-        match func(handle, buffer.as_mut_ptr(), &raw mut size) {
-            ErrorCode::Success => {
-                buffer.set_len(size as usize);
-                println!("{buffer:?}");
-                let string = CString::from_vec_with_nul(buffer).unwrap();
-                let string = string.into_string().unwrap();
+    let code = unsafe { func(handle, buffer.as_mut_ptr(), &mut size) };
 
-                return Ok(string);
-            }
-            e => return Err(e.into()),
-        }
+    if code != ErrorCode::Success {
+        return Err(code.into());
     }
+
+    CString::from_vec_with_nul(buffer)?
+        .into_string()
+        .map_err(IntoStringError::into_cstring)
+        .map_err(StringError::InvalidUtf8)
 }
 
-pub fn initialize_path() -> PathBuf {
+#[cfg(test)]
+pub fn initialize_path() -> std::path::PathBuf {
     let manifest_path = std::env!("CARGO_MANIFEST_DIR");
-    let mut path = PathBuf::from(manifest_path);
+    let mut path = std::path::PathBuf::from(manifest_path);
     path.push("standard.osu");
 
     path

--- a/osu-native/src/utils/mod.rs
+++ b/osu-native/src/utils/mod.rs
@@ -21,8 +21,8 @@ pub enum StringError {
     InvalidLength(i32),
     #[error("Received invalid string")]
     InvalidNul(#[from] FromVecWithNulError),
-    #[error("Received invalid utf8 string: {0:?}")]
-    InvalidUtf8(CString),
+    #[error("Received invalid utf8 string")]
+    InvalidUtf8(#[from] IntoStringError),
     #[error("Native error")]
     Native(#[from] NativeError),
 }
@@ -59,8 +59,7 @@ pub(crate) fn read_native_string(
 
     CString::from_vec_with_nul(buffer)?
         .into_string()
-        .map_err(IntoStringError::into_cstring)
-        .map_err(StringError::InvalidUtf8)
+        .map_err(Into::into)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Some general cleanups and restructuring.

Uses `thiserror` for error declarations which does bring in some more dependencies so this could be removed later on but for the time being it simplifies things.