### PR TITLE
refactor: wrap native types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ let beatmap = Beatmap::new_from_path("/path/to/map")?;
 let title = beatmap.get_title()?;
 println!("{title}");
 
-let ruleset = Ruleset::new_from_variant(Rulesets::Standard)?;
+let ruleset = Ruleset::from_kind_from_variant(Rulesets::Standard)?;
 let short_name = ruleset.get_short_name()?;
 println!("{short_name}")
 

--- a/libosu-native-sys/src/lib.rs
+++ b/libosu-native-sys/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 #[repr(C)]
 pub struct NativeOsuDifficultyAttributes {
     pub star_rating: f64,
@@ -55,8 +54,8 @@ pub struct NativeScoreHitStatistics {
     pub large_tick_miss: i32,
 }
 
-#[repr(i8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(i8)]
 pub enum ErrorCode {
     BufferSizeQuery = -1,
     Success = 0,
@@ -67,19 +66,66 @@ pub enum ErrorCode {
     Failure = 127,
 }
 
-pub type NativeModHandle = i32;
-pub type NativeModCollectionHandle = i32;
-pub type NativeBeatmapHandle = i32;
-pub type NativeRulesetHandle = i32;
-pub type NativeOsuDifficultyCalculatorHandle = i32;
-pub type NativeTaikoDifficultyCalculatorHandle = i32;
-pub type NativeManiaDifficultyCalculatorHandle = i32;
-pub type NativeCatchDifficultyCalculatorHandle = i32;
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct NativeOsuDifficultyCalculator {
+    pub handle: NativeOsuDifficultyCalculatorHandle,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeOsuDifficultyCalculatorHandle(i32);
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct NativeTaikoDifficultyCalculator {
+    pub handle: NativeTaikoDifficultyCalculatorHandle,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeTaikoDifficultyCalculatorHandle(i32);
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct NativeCatchDifficultyCalculator {
+    pub handle: NativeCatchDifficultyCalculatorHandle,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeCatchDifficultyCalculatorHandle(i32);
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct NativeManiaDifficultyCalculator {
+    pub handle: NativeManiaDifficultyCalculatorHandle,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeManiaDifficultyCalculatorHandle(i32);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeModHandle(i32);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeModCollectionHandle(i32);
+
+#[derive(Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct NativeRuleset {
     pub handle: NativeRulesetHandle,
     pub id: i32,
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeRulesetHandle(i32);
+
+#[derive(Debug, PartialEq)]
 #[repr(C)]
 pub struct NativeBeatmap {
     pub handle: NativeBeatmapHandle,
@@ -90,18 +136,24 @@ pub struct NativeBeatmap {
     pub slider_multiplier: f64,
     pub slider_tick_rate: f64,
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NativeBeatmapHandle(i32);
+
 #[cfg_attr(target_os = "windows", link(name = "osu.Native", kind = "dylib"))]
 #[cfg_attr(
     not(target_os = "windows"),
     link(name = "osu.Native.so", modifiers = "+verbatim")
 )]
 unsafe extern "C" {
-    // Mods
+    // Mod
     pub fn Mod_Create(acronym: *const i8, mod_handle_ptr: *mut NativeModHandle) -> ErrorCode;
     pub fn Mod_SetSetting(mod_handle: NativeModHandle, key: *const i8, value: f64) -> ErrorCode;
     pub fn Mod_Debug(mod_handle: NativeModHandle) -> ErrorCode;
     pub fn Mod_Destroy(mod_handle: NativeModHandle) -> ErrorCode;
-    // Mod collections
+
+    // Mod collection
     pub fn ModsCollection_Create(mod_collection_ptr: *mut NativeModCollectionHandle) -> ErrorCode;
     pub fn ModsCollection_Add(
         mod_collection_handle: NativeModCollectionHandle,
@@ -112,14 +164,12 @@ unsafe extern "C" {
         mod_handle: NativeModHandle,
     ) -> ErrorCode;
     pub fn ModsCollection_Destroy(mod_collection_handle: NativeModCollectionHandle) -> ErrorCode;
+
     // Rulesets
-    pub fn Ruleset_CreateFromId(
-        ruleset_id: i32,
-        ruleset_handle_ptr: *mut NativeRuleset,
-    ) -> ErrorCode;
+    pub fn Ruleset_CreateFromId(ruleset_id: i32, ruleset_ptr: *mut NativeRuleset) -> ErrorCode;
     pub fn Ruleset_CreateFromShortName(
         short_name: *const u8,
-        ruleset_handle_ptr: *mut NativeRuleset,
+        ruleset_ptr: *mut NativeRuleset,
     ) -> ErrorCode;
     pub fn Ruleset_GetShortName(
         ruleset_handle: NativeRulesetHandle,
@@ -127,6 +177,7 @@ unsafe extern "C" {
         size: *mut i32,
     ) -> ErrorCode;
     pub fn Ruleset_Destroy(ruleset_handle: NativeRulesetHandle) -> ErrorCode;
+
     // Beatmaps
     pub fn Beatmap_CreateFromFile(path: *const i8, beatmap_ptr: *mut NativeBeatmap) -> ErrorCode;
     pub fn Beatmap_CreateFromText(text: *const i8, beatmap_ptr: *mut NativeBeatmap) -> ErrorCode;
@@ -146,12 +197,13 @@ unsafe extern "C" {
         size: *mut i32,
     ) -> ErrorCode;
     pub fn Beatmap_Destroy(beatmap_handle: NativeBeatmapHandle) -> ErrorCode;
+
     /// Difficulty Calculator Objects (CDO)
     // ODCO
     pub fn OsuDifficultyCalculator_Create(
         ruleset_handle: NativeRulesetHandle,
         beatmap_handle: NativeBeatmapHandle,
-        calculator_ptr: *mut NativeOsuDifficultyCalculatorHandle,
+        calculator_ptr: *mut NativeOsuDifficultyCalculator,
     ) -> ErrorCode;
     pub fn OsuDifficultyCalculator_Calculate(
         calculator_handle: NativeOsuDifficultyCalculatorHandle,
@@ -160,15 +212,18 @@ unsafe extern "C" {
     pub fn OsuDifficultyCalculator_CalculateMods(
         calculator_handle: NativeOsuDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mods_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModCollectionHandle,
         attributes_ptr: *mut NativeOsuDifficultyAttributes,
     ) -> ErrorCode;
-    pub fn OsuDifficultyCalculator_Destroy(calculator_handle: NativeOsuDifficultyCalculatorHandle);
+    pub fn OsuDifficultyCalculator_Destroy(
+        calculator_handle: NativeOsuDifficultyCalculatorHandle,
+    ) -> ErrorCode;
+
     // TDCO
     pub fn TaikoDifficultyCalculator_Create(
         ruleset_handle: NativeRulesetHandle,
         beatmap_handle: NativeBeatmapHandle,
-        calculator_ptr: *mut NativeTaikoDifficultyCalculatorHandle,
+        calculator_ptr: *mut NativeTaikoDifficultyCalculator,
     ) -> ErrorCode;
     pub fn TaikoDifficultyCalculator_Calculate(
         calculator_handle: NativeTaikoDifficultyCalculatorHandle,
@@ -177,17 +232,18 @@ unsafe extern "C" {
     pub fn TaikoDifficultyCalculator_CalculateMods(
         calculator_handle: NativeTaikoDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mods_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModCollectionHandle,
         attributes_ptr: *mut NativeTaikoDifficultyAttributes,
     ) -> ErrorCode;
     pub fn TaikoDifficultyCalculator_Destroy(
         calculator_handle: NativeTaikoDifficultyCalculatorHandle,
-    );
+    ) -> ErrorCode;
+
     // MDCO
     pub fn ManiaDifficultyCalculator_Create(
         ruleset_handle: NativeRulesetHandle,
         beatmap_handle: NativeBeatmapHandle,
-        calculator_ptr: *mut NativeManiaDifficultyCalculatorHandle,
+        calculator_ptr: *mut NativeManiaDifficultyCalculator,
     ) -> ErrorCode;
     pub fn ManiaDifficultyCalculator_Calculate(
         calculator_handle: NativeManiaDifficultyCalculatorHandle,
@@ -196,17 +252,18 @@ unsafe extern "C" {
     pub fn ManiaDifficultyCalculator_CalculateMods(
         calculator_handle: NativeManiaDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mods_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModCollectionHandle,
         attributes_ptr: *mut NativeManiaDifficultyAttributes,
     ) -> ErrorCode;
     pub fn ManiaDifficultyCalculator_Destroy(
         calculator_handle: NativeManiaDifficultyCalculatorHandle,
-    );
+    ) -> ErrorCode;
+
     // CDCO
     pub fn CatchDifficultyCalculator_Create(
         ruleset_handle: NativeRulesetHandle,
         beatmap_handle: NativeBeatmapHandle,
-        calculator_ptr: *mut NativeCatchDifficultyCalculatorHandle,
+        calculator_ptr: *mut NativeCatchDifficultyCalculator,
     ) -> ErrorCode;
     pub fn CatchDifficultyCalculator_Calculate(
         calculator_handle: NativeCatchDifficultyCalculatorHandle,
@@ -215,11 +272,10 @@ unsafe extern "C" {
     pub fn CatchDifficultyCalculator_CalculateMods(
         calculator_handle: NativeCatchDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mods_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModCollectionHandle,
         attributes_ptr: *mut NativeCatchDifficultyAttributes,
     ) -> ErrorCode;
     pub fn CatchDifficultyCalculator_Destroy(
         calculator_handle: NativeCatchDifficultyCalculatorHandle,
-    );
-
+    ) -> ErrorCode;
 }

--- a/libosu-native-sys/src/lib.rs
+++ b/libosu-native-sys/src/lib.rs
@@ -106,13 +106,25 @@ pub struct NativeManiaDifficultyCalculator {
 #[repr(transparent)]
 pub struct NativeManiaDifficultyCalculatorHandle(i32);
 
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct NativeMod {
+    pub handle: NativeModHandle,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct NativeModHandle(i32);
 
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct NativeModsCollection {
+    pub handle: NativeModsCollectionHandle,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct NativeModCollectionHandle(i32);
+pub struct NativeModsCollectionHandle(i32);
 
 #[derive(Debug, PartialEq, Eq)]
 #[repr(C)]
@@ -148,22 +160,22 @@ pub struct NativeBeatmapHandle(i32);
 )]
 unsafe extern "C" {
     // Mod
-    pub fn Mod_Create(acronym: *const i8, mod_handle_ptr: *mut NativeModHandle) -> ErrorCode;
+    pub fn Mod_Create(acronym: *const i8, mod_handle_ptr: *mut NativeMod) -> ErrorCode;
     pub fn Mod_SetSetting(mod_handle: NativeModHandle, key: *const i8, value: f64) -> ErrorCode;
     pub fn Mod_Debug(mod_handle: NativeModHandle) -> ErrorCode;
     pub fn Mod_Destroy(mod_handle: NativeModHandle) -> ErrorCode;
 
     // Mod collection
-    pub fn ModsCollection_Create(mod_collection_ptr: *mut NativeModCollectionHandle) -> ErrorCode;
+    pub fn ModsCollection_Create(mod_collection_ptr: *mut NativeModsCollection) -> ErrorCode;
     pub fn ModsCollection_Add(
-        mod_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModsCollectionHandle,
         mod_handle: NativeModHandle,
     ) -> ErrorCode;
     pub fn ModsCollection_Remove(
-        mod_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModsCollectionHandle,
         mod_handle: NativeModHandle,
     ) -> ErrorCode;
-    pub fn ModsCollection_Destroy(mod_collection_handle: NativeModCollectionHandle) -> ErrorCode;
+    pub fn ModsCollection_Destroy(mod_collection_handle: NativeModsCollectionHandle) -> ErrorCode;
 
     // Rulesets
     pub fn Ruleset_CreateFromId(ruleset_id: i32, ruleset_ptr: *mut NativeRuleset) -> ErrorCode;
@@ -212,7 +224,7 @@ unsafe extern "C" {
     pub fn OsuDifficultyCalculator_CalculateMods(
         calculator_handle: NativeOsuDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mod_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModsCollectionHandle,
         attributes_ptr: *mut NativeOsuDifficultyAttributes,
     ) -> ErrorCode;
     pub fn OsuDifficultyCalculator_Destroy(
@@ -232,7 +244,7 @@ unsafe extern "C" {
     pub fn TaikoDifficultyCalculator_CalculateMods(
         calculator_handle: NativeTaikoDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mod_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModsCollectionHandle,
         attributes_ptr: *mut NativeTaikoDifficultyAttributes,
     ) -> ErrorCode;
     pub fn TaikoDifficultyCalculator_Destroy(
@@ -252,7 +264,7 @@ unsafe extern "C" {
     pub fn ManiaDifficultyCalculator_CalculateMods(
         calculator_handle: NativeManiaDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mod_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModsCollectionHandle,
         attributes_ptr: *mut NativeManiaDifficultyAttributes,
     ) -> ErrorCode;
     pub fn ManiaDifficultyCalculator_Destroy(
@@ -272,7 +284,7 @@ unsafe extern "C" {
     pub fn CatchDifficultyCalculator_CalculateMods(
         calculator_handle: NativeCatchDifficultyCalculatorHandle,
         ruleset_handle: NativeRulesetHandle,
-        mod_collection_handle: NativeModCollectionHandle,
+        mod_collection_handle: NativeModsCollectionHandle,
         attributes_ptr: *mut NativeCatchDifficultyAttributes,
     ) -> ErrorCode;
     pub fn CatchDifficultyCalculator_Destroy(

--- a/osu-native/src/beatmap/mod.rs
+++ b/osu-native/src/beatmap/mod.rs
@@ -12,12 +12,12 @@ use crate::{
     utils::{StringError, read_native_string},
 };
 
+impl_native!(NativeBeatmap: NativeBeatmapHandle, Beatmap_Destroy);
+
 declare_native_wrapper! {
     #[derive(Debug, PartialEq)]
     pub struct Beatmap(NativeBeatmap);
 }
-
-impl_native!(NativeBeatmap: NativeBeatmapHandle, Beatmap_Destroy);
 
 #[derive(Debug, ThisError)]
 pub enum BeatmapError {

--- a/osu-native/src/calculator/catch.rs
+++ b/osu-native/src/calculator/catch.rs
@@ -1,8 +1,6 @@
-use std::mem::MaybeUninit;
-
 use libosu_native_sys::{
     CatchDifficultyCalculator_CalculateMods, CatchDifficultyCalculator_Create,
-    CatchDifficultyCalculator_Destroy, ErrorCode, NativeCatchDifficultyAttributes,
+    CatchDifficultyCalculator_Destroy, NativeCatchDifficultyAttributes,
     NativeCatchDifficultyCalculator, NativeCatchDifficultyCalculatorHandle,
 };
 

--- a/osu-native/src/calculator/mania.rs
+++ b/osu-native/src/calculator/mania.rs
@@ -3,54 +3,50 @@ use std::mem::MaybeUninit;
 use libosu_native_sys::{
     ErrorCode, ManiaDifficultyCalculator_CalculateMods, ManiaDifficultyCalculator_Create,
     ManiaDifficultyCalculator_Destroy, NativeManiaDifficultyAttributes,
+    NativeManiaDifficultyCalculator, NativeManiaDifficultyCalculatorHandle,
 };
 
 use crate::{
-    beatmap::Beatmap,
+    calculator::CreateFn,
     error::OsuError,
     mods::{
         GameMods, GameModsError, IntoGameMods,
         native::{Mod, ModCollection},
     },
     ruleset::Ruleset,
-    utils::HasNative,
+    traits::Native,
 };
 
 use super::DifficultyCalculator;
 
-#[derive(PartialEq)]
-pub struct ManiaDifficultyCalculator {
-    handle: i32,
-    ruleset: Ruleset,
-    mods: GameMods,
-}
-
-impl Drop for ManiaDifficultyCalculator {
-    fn drop(&mut self) {
-        unsafe { ManiaDifficultyCalculator_Destroy(self.handle) };
+declare_native_wrapper! {
+    #[derive(Debug, PartialEq)]
+    pub struct ManiaDifficultyCalculator {
+        native: NativeManiaDifficultyCalculator,
+        ruleset: Ruleset,
+        mods: GameMods,
     }
 }
+
+impl From<(NativeManiaDifficultyCalculator, Ruleset)> for ManiaDifficultyCalculator {
+    fn from((native, ruleset): (NativeManiaDifficultyCalculator, Ruleset)) -> Self {
+        Self {
+            native,
+            ruleset,
+            mods: GameMods::default(),
+        }
+    }
+}
+
+impl_native!(
+    NativeManiaDifficultyCalculator:
+        NativeManiaDifficultyCalculatorHandle, ManiaDifficultyCalculator_Destroy
+);
 
 impl DifficultyCalculator for ManiaDifficultyCalculator {
     type Attributes = ManiaDifficultyAttributes;
 
-    fn new(ruleset: Ruleset, beatmap: &Beatmap) -> Result<Self, OsuError> {
-        let mut handle = 0;
-
-        let code = unsafe {
-            ManiaDifficultyCalculator_Create(ruleset.handle(), beatmap.handle(), &mut handle)
-        };
-
-        if code != ErrorCode::Success {
-            return Err(code.into());
-        }
-
-        Ok(Self {
-            handle,
-            ruleset,
-            mods: GameMods::default(),
-        })
-    }
+    const CREATE: CreateFn<Self::Native> = ManiaDifficultyCalculator_Create;
 
     fn mods(mut self, mods: impl IntoGameMods) -> Result<Self, GameModsError> {
         self.mods = mods.into_mods()?;
@@ -81,7 +77,7 @@ impl DifficultyCalculator for ManiaDifficultyCalculator {
 
         let code = unsafe {
             ManiaDifficultyCalculator_CalculateMods(
-                self.handle,
+                self.handle(),
                 self.ruleset.handle(),
                 mods.handle(),
                 attributes.as_mut_ptr(),
@@ -112,10 +108,6 @@ pub struct ManiaDifficultyAttributes {
     pub max_combo: usize,
 }
 
-impl HasNative for ManiaDifficultyAttributes {
-    type Native = NativeManiaDifficultyAttributes;
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -132,8 +124,8 @@ mod tests {
     #[test]
     fn test_toy_box_convert_mania() {
         let beatmap = Beatmap::from_path(initialize_path()).unwrap();
-        let ruleset = Ruleset::new(RulesetKind::Mania).unwrap();
-        let calculator = ManiaDifficultyCalculator::new(ruleset, &beatmap).unwrap();
+        let ruleset = Ruleset::from_kind(RulesetKind::Mania).unwrap();
+        let calculator = ManiaDifficultyCalculator::create(ruleset, &beatmap).unwrap();
         let attributes = calculator.calculate().unwrap();
         assert_ne!(attributes.star_rating, 0.0);
         assert_eq!(attributes.max_combo, 1463);
@@ -141,15 +133,15 @@ mod tests {
     #[test]
     fn test_toy_box_mania_with_mods() {
         let beatmap = Beatmap::from_path(initialize_path()).unwrap();
-        let ruleset = Ruleset::new(RulesetKind::Mania).unwrap();
-        let calculator = ManiaDifficultyCalculator::new(ruleset, &beatmap).unwrap();
+        let ruleset = Ruleset::from_kind(RulesetKind::Mania).unwrap();
+        let calculator = ManiaDifficultyCalculator::create(ruleset, &beatmap).unwrap();
         let attributes = calculator.calculate().unwrap();
-        let ruleset = Ruleset::new(RulesetKind::Mania).unwrap();
+        let ruleset = Ruleset::from_kind(RulesetKind::Mania).unwrap();
         let mods: GameModSimple = GameModSimple {
             acronym: Acronym::from_str("DT").unwrap(),
             settings: Default::default(),
         };
-        let calculator_with_mods = ManiaDifficultyCalculator::new(ruleset, &beatmap)
+        let calculator_with_mods = ManiaDifficultyCalculator::create(ruleset, &beatmap)
             .unwrap()
             .mods(vec![mods])
             .unwrap();

--- a/osu-native/src/calculator/mania.rs
+++ b/osu-native/src/calculator/mania.rs
@@ -1,7 +1,5 @@
-use std::mem::MaybeUninit;
-
 use libosu_native_sys::{
-    ErrorCode, ManiaDifficultyCalculator_CalculateMods, ManiaDifficultyCalculator_Create,
+    ManiaDifficultyCalculator_CalculateMods, ManiaDifficultyCalculator_Create,
     ManiaDifficultyCalculator_Destroy, NativeManiaDifficultyAttributes,
     NativeManiaDifficultyCalculator, NativeManiaDifficultyCalculatorHandle,
 };

--- a/osu-native/src/calculator/mod.rs
+++ b/osu-native/src/calculator/mod.rs
@@ -1,13 +1,9 @@
-use std::mem::MaybeUninit;
-
-use libosu_native_sys::{ErrorCode, NativeBeatmapHandle, NativeRulesetHandle};
-
 use crate::{
     beatmap::Beatmap,
     error::{NativeError, OsuError},
     mods::{GameModsError, IntoGameMods},
     ruleset::Ruleset,
-    traits::{Native, NativeWrapper},
+    traits::NativeWrapper,
 };
 
 pub mod catch;
@@ -15,30 +11,12 @@ pub mod mania;
 pub mod osu;
 pub mod taiko;
 
-type CreateFn<N> =
-    unsafe extern "C" fn(NativeRulesetHandle, NativeBeatmapHandle, *mut N) -> ErrorCode;
-
-pub trait DifficultyCalculator: Sized + NativeWrapper + From<(Self::Native, Ruleset)> {
+pub trait DifficultyCalculator: Sized + NativeWrapper {
     type Attributes;
 
-    const CREATE: CreateFn<Self::Native>;
-
-    fn calculate(&self) -> Result<Self::Attributes, OsuError>;
+    fn create(ruleset: Ruleset, beatmap: &Beatmap) -> Result<Self, NativeError>;
 
     fn mods(self, mods: impl IntoGameMods) -> Result<Self, GameModsError>;
 
-    fn create(ruleset: Ruleset, beatmap: &Beatmap) -> Result<Self, NativeError> {
-        let mut calculator = MaybeUninit::uninit();
-
-        let code =
-            unsafe { Self::CREATE(ruleset.handle(), beatmap.handle(), calculator.as_mut_ptr()) };
-
-        if code != ErrorCode::Success {
-            return Err(code.into());
-        }
-
-        let native = unsafe { calculator.assume_init() };
-
-        Ok(Self::from((native, ruleset)))
-    }
+    fn calculate(&self) -> Result<Self::Attributes, OsuError>;
 }

--- a/osu-native/src/calculator/mod.rs
+++ b/osu-native/src/calculator/mod.rs
@@ -1,9 +1,13 @@
+use std::mem::MaybeUninit;
+
+use libosu_native_sys::{ErrorCode, NativeBeatmapHandle, NativeRulesetHandle};
+
 use crate::{
     beatmap::Beatmap,
-    error::OsuError,
+    error::{NativeError, OsuError},
     mods::{GameModsError, IntoGameMods},
     ruleset::Ruleset,
-    utils::HasNative,
+    traits::{Native, NativeWrapper},
 };
 
 pub mod catch;
@@ -11,12 +15,30 @@ pub mod mania;
 pub mod osu;
 pub mod taiko;
 
-pub trait DifficultyCalculator: Sized {
-    type Attributes: HasNative;
+type CreateFn<N> =
+    unsafe extern "C" fn(NativeRulesetHandle, NativeBeatmapHandle, *mut N) -> ErrorCode;
 
-    fn new(ruleset: Ruleset, beatmap: &Beatmap) -> Result<Self, OsuError>;
+pub trait DifficultyCalculator: Sized + NativeWrapper + From<(Self::Native, Ruleset)> {
+    type Attributes;
+
+    const CREATE: CreateFn<Self::Native>;
+
+    fn calculate(&self) -> Result<Self::Attributes, OsuError>;
 
     fn mods(self, mods: impl IntoGameMods) -> Result<Self, GameModsError>;
 
-    fn calculate(&self) -> Result<Self::Attributes, OsuError>;
+    fn create(ruleset: Ruleset, beatmap: &Beatmap) -> Result<Self, NativeError> {
+        let mut calculator = MaybeUninit::uninit();
+
+        let code =
+            unsafe { Self::CREATE(ruleset.handle(), beatmap.handle(), calculator.as_mut_ptr()) };
+
+        if code != ErrorCode::Success {
+            return Err(code.into());
+        }
+
+        let native = unsafe { calculator.assume_init() };
+
+        Ok(Self::from((native, ruleset)))
+    }
 }

--- a/osu-native/src/calculator/osu.rs
+++ b/osu-native/src/calculator/osu.rs
@@ -1,7 +1,5 @@
-use std::mem::MaybeUninit;
-
 use libosu_native_sys::{
-    ErrorCode, NativeOsuDifficultyAttributes, NativeOsuDifficultyCalculator,
+    NativeOsuDifficultyAttributes, NativeOsuDifficultyCalculator,
     NativeOsuDifficultyCalculatorHandle, OsuDifficultyCalculator_CalculateMods,
     OsuDifficultyCalculator_Create, OsuDifficultyCalculator_Destroy,
 };

--- a/osu-native/src/calculator/osu.rs
+++ b/osu-native/src/calculator/osu.rs
@@ -1,56 +1,52 @@
 use std::mem::MaybeUninit;
 
 use libosu_native_sys::{
-    ErrorCode, NativeOsuDifficultyAttributes, OsuDifficultyCalculator_CalculateMods,
+    ErrorCode, NativeOsuDifficultyAttributes, NativeOsuDifficultyCalculator,
+    NativeOsuDifficultyCalculatorHandle, OsuDifficultyCalculator_CalculateMods,
     OsuDifficultyCalculator_Create, OsuDifficultyCalculator_Destroy,
 };
 
 use crate::{
-    beatmap::Beatmap,
+    calculator::CreateFn,
     error::OsuError,
     mods::{
         GameMods, GameModsError, IntoGameMods,
         native::{Mod, ModCollection},
     },
     ruleset::Ruleset,
-    utils::HasNative,
+    traits::Native,
 };
 
 use super::DifficultyCalculator;
 
-#[derive(PartialEq)]
-pub struct OsuDifficultyCalculator {
-    handle: i32,
-    ruleset: Ruleset,
-    mods: GameMods,
-}
-
-impl Drop for OsuDifficultyCalculator {
-    fn drop(&mut self) {
-        unsafe { OsuDifficultyCalculator_Destroy(self.handle) };
+declare_native_wrapper! {
+    #[derive(Debug, PartialEq)]
+    pub struct OsuDifficultyCalculator {
+        native: NativeOsuDifficultyCalculator,
+        ruleset: Ruleset,
+        mods: GameMods,
     }
 }
+
+impl From<(NativeOsuDifficultyCalculator, Ruleset)> for OsuDifficultyCalculator {
+    fn from((native, ruleset): (NativeOsuDifficultyCalculator, Ruleset)) -> Self {
+        Self {
+            native,
+            ruleset,
+            mods: GameMods::default(),
+        }
+    }
+}
+
+impl_native!(
+    NativeOsuDifficultyCalculator:
+        NativeOsuDifficultyCalculatorHandle, OsuDifficultyCalculator_Destroy
+);
 
 impl DifficultyCalculator for OsuDifficultyCalculator {
     type Attributes = OsuDifficultyAttributes;
 
-    fn new(ruleset: Ruleset, beatmap: &Beatmap) -> Result<Self, OsuError> {
-        let mut handle = 0;
-
-        let code = unsafe {
-            OsuDifficultyCalculator_Create(ruleset.handle(), beatmap.handle(), &mut handle)
-        };
-
-        if code != ErrorCode::Success {
-            return Err(code.into());
-        }
-
-        Ok(Self {
-            handle,
-            ruleset,
-            mods: GameMods::default(),
-        })
-    }
+    const CREATE: CreateFn<Self::Native> = OsuDifficultyCalculator_Create;
 
     fn mods(mut self, mods: impl IntoGameMods) -> Result<Self, GameModsError> {
         self.mods = mods.into_mods()?;
@@ -116,10 +112,6 @@ pub struct OsuDifficultyAttributes {
     pub spinner_count: i32,
 }
 
-impl HasNative for OsuDifficultyAttributes {
-    type Native = NativeOsuDifficultyAttributes;
-}
-
 impl From<NativeOsuDifficultyAttributes> for OsuDifficultyAttributes {
     fn from(value: NativeOsuDifficultyAttributes) -> Self {
         Self {
@@ -151,7 +143,6 @@ mod tests {
     use crate::{
         beatmap::Beatmap,
         calculator::DifficultyCalculator,
-        mods::native::{Mod, ModCollection},
         ruleset::{Ruleset, RulesetKind},
         utils::initialize_path,
     };
@@ -159,8 +150,8 @@ mod tests {
     #[test]
     fn test_toy_box_osu() {
         let beatmap = Beatmap::from_path(initialize_path()).unwrap();
-        let ruleset = Ruleset::new(RulesetKind::Osu).unwrap();
-        let calculator = OsuDifficultyCalculator::new(ruleset, &beatmap).unwrap();
+        let ruleset = Ruleset::from_kind(RulesetKind::Osu).unwrap();
+        let calculator = OsuDifficultyCalculator::create(ruleset, &beatmap).unwrap();
         let attributes = calculator.calculate().unwrap();
         assert_ne!(attributes.star_rating, 0.0);
         assert_eq!(attributes.max_combo, 719);
@@ -180,16 +171,16 @@ mod tests {
     #[test]
     fn test_toy_box_osu_with_mods() {
         let beatmap = Beatmap::from_path(initialize_path()).unwrap();
-        let ruleset = Ruleset::new(RulesetKind::Osu).unwrap();
-        let calculator = OsuDifficultyCalculator::new(ruleset, &beatmap).unwrap();
+        let ruleset = Ruleset::from_kind(RulesetKind::Osu).unwrap();
+        let calculator = OsuDifficultyCalculator::create(ruleset, &beatmap).unwrap();
         let attributes = calculator.calculate().unwrap();
 
         let mods: GameModSimple = GameModSimple {
             acronym: Acronym::from_str("DT").unwrap(),
             settings: Default::default(),
         };
-        let ruleset = Ruleset::new(RulesetKind::Osu).unwrap();
-        let calculator_with_mods = OsuDifficultyCalculator::new(ruleset, &beatmap)
+        let ruleset = Ruleset::from_kind(RulesetKind::Osu).unwrap();
+        let calculator_with_mods = OsuDifficultyCalculator::create(ruleset, &beatmap)
             .unwrap()
             .mods(vec![mods])
             .unwrap();
@@ -203,8 +194,8 @@ mod tests {
     #[should_panic]
     fn test_calculator_ruleset_mismatch() {
         let beatmap = Beatmap::from_path(initialize_path()).unwrap();
-        let ruleset = Ruleset::new(RulesetKind::Taiko).unwrap();
+        let ruleset = Ruleset::from_kind(RulesetKind::Taiko).unwrap();
         // Panics because of ruleset and calculator don't match
-        let _ = OsuDifficultyCalculator::new(ruleset, &beatmap).unwrap();
+        let _ = OsuDifficultyCalculator::create(ruleset, &beatmap).unwrap();
     }
 }

--- a/osu-native/src/calculator/taiko.rs
+++ b/osu-native/src/calculator/taiko.rs
@@ -1,7 +1,5 @@
-use std::mem::MaybeUninit;
-
 use libosu_native_sys::{
-    ErrorCode, NativeTaikoDifficultyAttributes, NativeTaikoDifficultyCalculator,
+    NativeTaikoDifficultyAttributes, NativeTaikoDifficultyCalculator,
     NativeTaikoDifficultyCalculatorHandle, TaikoDifficultyCalculator_CalculateMods,
     TaikoDifficultyCalculator_Create, TaikoDifficultyCalculator_Destroy,
 };

--- a/osu-native/src/lib.rs
+++ b/osu-native/src/lib.rs
@@ -1,6 +1,9 @@
+#[macro_use]
+mod utils;
+
 pub mod beatmap;
 pub mod calculator;
 pub mod error;
 pub mod mods;
 pub mod ruleset;
-mod utils;
+pub mod traits;

--- a/osu-native/src/ruleset/mod.rs
+++ b/osu-native/src/ruleset/mod.rs
@@ -51,12 +51,12 @@ impl TryFrom<i32> for RulesetKind {
     }
 }
 
+impl_native!(NativeRuleset: NativeRulesetHandle, Ruleset_Destroy);
+
 declare_native_wrapper! {
     #[derive(Debug, PartialEq, Eq)]
     pub struct Ruleset(NativeRuleset);
 }
-
-impl_native!(NativeRuleset: NativeRulesetHandle, Ruleset_Destroy);
 
 impl Ruleset {
     pub fn from_kind(kind: RulesetKind) -> Result<Self, NativeError> {

--- a/osu-native/src/traits.rs
+++ b/osu-native/src/traits.rs
@@ -1,0 +1,20 @@
+use std::fmt::Debug;
+
+use libosu_native_sys::ErrorCode;
+
+/// A wrapper around a [`Native`] type.
+pub trait NativeWrapper {
+    // `Debug` bound necessary for error message in case `Drop` fails
+    type Native: Native<Handle: Debug>;
+}
+
+pub(crate) type DestroyFn<H> = unsafe extern "C" fn(H) -> ErrorCode;
+
+/// A native type coming from C#.
+pub trait Native {
+    type Handle;
+
+    const DESTROY: DestroyFn<Self::Handle>;
+
+    fn handle(&self) -> Self::Handle;
+}

--- a/osu-native/src/utils/macros.rs
+++ b/osu-native/src/utils/macros.rs
@@ -1,0 +1,129 @@
+/// Implements [`NativeWrapper`], [`Deref`], [`From<Native>`] and [`Drop`] for
+/// native wrappers.
+///
+/// [`NativeWrapper`]: crate::traits::NativeWrapper
+/// [`Deref`]: std::ops::Deref
+/// [`From<Native>`]: std::convert::From
+macro_rules! declare_native_wrapper {
+    // Entrypoint for simple tuple wrappers
+    (
+        #[$meta:meta]
+        $vis:vis struct $name:ident($native:ident);
+    ) => {
+        #[$meta]
+        #[doc = declare_native_wrapper!(@DOC $native)]
+        $vis struct $name($native);
+
+        impl std::ops::Deref for $name {
+            type Target = $native;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl From<($native, crate::ruleset::Ruleset)> for $name {
+            fn from((native, _): ($native, crate::ruleset::Ruleset)) -> Self {
+                Self(native)
+            }
+        }
+
+        declare_native_wrapper!(@NATIVE $name: $native);
+        declare_native_wrapper!(@DROP $name);
+    };
+    // Entrypoint for named field structs
+    (
+        #[$meta:meta]
+        $vis:vis struct $name:ident {
+            $( $field_vis:vis $field_name:ident: $field_type:ty, )*
+        }
+    ) => {
+        declare_native_wrapper! {
+            #[$meta]
+            $vis struct $name
+                [declare_native_wrapper!(@FIND_NATIVE $( $field_name $field_type, )*)]
+            {
+                $( $field_vis $field_name: $field_type, )*
+            }
+        }
+    };
+    // Actual handling of named field structs and their native type
+    (
+        #[$meta:meta]
+        $vis:vis struct $name:ident [$native:ty] {
+            $( $field_vis:vis $field_name:ident: $field_type:ty, )*
+        }
+    ) => {
+        #[$meta]
+        #[doc = declare_native_wrapper!(@DOC $native)]
+        $vis struct $name {
+            $( $field_vis $field_name: $field_type, )*
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = $native;
+
+            fn deref(&self) -> &Self::Target {
+                &self.native
+            }
+        }
+
+        declare_native_wrapper!(@NATIVE $name: $native);
+        declare_native_wrapper!( @DROP $name );
+    };
+    // Found field called `native` so we return its type
+    ( @FIND_NATIVE native $field_type:ty, $( $rest:tt )* ) => {
+        $field_type
+    };
+    // Current field is not called `native` so keep looking
+    ( @FIND_NATIVE $field_name:ident $field_type:ty, $( $rest:tt )* ) => {
+        declare_native_wrapper!(@FIND_NATIVE $( $rest )*)
+    };
+    // No field called `native` found
+    ( @FIND_NATIVE ) => {
+        compile_error!("must contain field called `native`");
+    };
+    // Documentation for wrapper type
+    ( @DOC $native:ty ) => {
+        concat!("Wrapper around [`", stringify!($native), "`].")
+    };
+    // `NativeWrapper` trait implementation
+    ( @NATIVE $name:ident: $native:ty ) => {
+        impl crate::traits::NativeWrapper for $name {
+            type Native = $native;
+        }
+    };
+    // `Drop` trait implementation
+    ( @DROP $name:ident ) => {
+        impl Drop for $name {
+            fn drop(&mut self) {
+                let code = unsafe {
+                    <<Self as crate::traits::NativeWrapper>::Native as Native>::DESTROY(
+                        self.handle(),
+                    )
+                };
+
+                if code != ::libosu_native_sys::ErrorCode::Success {
+                    eprintln!("Failed to destroy object {:?}: {code:?}", self.handle());
+                }
+            }
+        }
+    }
+}
+
+/// Implements [`Native`] for native types.
+///
+/// [`Native`]: crate::traits::Native
+macro_rules! impl_native {
+    ( $name:ident: $handle:ident, $destroy:ident ) => {
+        impl crate::traits::Native for $name {
+            type Handle = $handle;
+
+            const DESTROY: crate::traits::DestroyFn<Self::Handle> = $destroy;
+
+            fn handle(&self) -> Self::Handle {
+                self.handle
+            }
+        }
+    };
+}


### PR DESCRIPTION
Restructuring native types and their wrappers.

This introduces the two traits `Native` and `NativeWrapper`, as well as a consistent structure for these wrappers. The traits are defined via macros to avoid manual boilerplate.

Also, instead of using `i32` as handles for all types, I created transparent wrappers for each type's handle to add some type safety.